### PR TITLE
added .d folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,9 @@ bld/
 # (https://github.com/github/gitignore/pull/3736)
 #!**/[Bb]in/*.refresh
 
+# build directory
+.d/
+
 # Visual Studio 2015/2017 cache/options directory
 .vs/
 # Uncomment if you have tasks that create the project's static files in wwwroot


### PR DESCRIPTION
Every time pros built it would make a bunch of *.cpp.d files in a directory .d/

This directory has been added to the .gitignore